### PR TITLE
fix: Change initialization order

### DIFF
--- a/src/entrypoints/coc.ts
+++ b/src/entrypoints/coc.ts
@@ -24,7 +24,6 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
   if (!paths.includes(context.extensionPath)) {
     await workspace.nvim.command(`execute 'noautocmd set runtimepath^='.fnameescape('${context.extensionPath}')`);
   }
-  await workspace.nvim.command('runtime plugin/tsdetect.vim');
 
   // Setup manual commands.
   (['deno', 'node'] as const).forEach((target) => {
@@ -55,4 +54,5 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
 
   // Initialize after launched coc-tsdetect.
   await initialize(context);
+  await workspace.nvim.command('runtime plugin/tsdetect.vim');
 };


### PR DESCRIPTION
Closes #7.  This PR moves the single line from L27 to L57.
L27 executed `runtime plugin/tsdetect.vim` . Then, Vim runs the auto command `User tsdetect#detect`. However, before L27, Vim has not defined such auto commands. In fact, the function initialize() first defined those auto commands. By moving it to L57, Vim throws no errors mentioned in #7. It seems no problem because there are no suspicious codes between L27 to L57 (there are only the registration commands for Coc.nvim). I hope that it works well.