### PR TITLE
Suppress autocmds errors

### DIFF
--- a/autoload/tsdetect.vim
+++ b/autoload/tsdetect.vim
@@ -19,6 +19,9 @@ function! tsdetect#init() abort
 
   augroup tsdetect#init
     autocmd!
+    autocmd User tsdetect#detect :
+    autocmd User tsdetect#detect#node :
+    autocmd User tsdetect#detect#deno :
     autocmd FileType javascript,javascriptreact,typescript,typescript.tsx,typescriptreact ++nested call <SID>detect_filetype()
     autocmd BufEnter,BufNewFile,BufWritePost * ++nested call <SID>detect_buffer(expand('<amatch>'))
   augroup END

--- a/autoload/tsdetect.vim
+++ b/autoload/tsdetect.vim
@@ -22,6 +22,8 @@ function! tsdetect#init() abort
     autocmd User tsdetect#detect :
     autocmd User tsdetect#detect#node :
     autocmd User tsdetect#detect#deno :
+    autocmd User tsdetect#coc#auto#switch#node#after :
+    autocmd User tsdetect#coc#auto#switch#deno#after :
     autocmd FileType javascript,javascriptreact,typescript,typescript.tsx,typescriptreact ++nested call <SID>detect_filetype()
     autocmd BufEnter,BufNewFile,BufWritePost * ++nested call <SID>detect_buffer(expand('<amatch>'))
   augroup END

--- a/src/entrypoints/coc.ts
+++ b/src/entrypoints/coc.ts
@@ -24,7 +24,6 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
   if (!paths.includes(context.extensionPath)) {
     await workspace.nvim.command(`execute 'noautocmd set runtimepath^='.fnameescape('${context.extensionPath}')`);
   }
-  await workspace.nvim.command('runtime plugin/tsdetect.vim');
 
   // Setup manual commands.
   (['deno', 'node'] as const).forEach((target) => {
@@ -55,4 +54,5 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
 
   // Initialize after launched coc-tsdetect.
   await initialize(context);
+  await workspace.nvim.command('runtime plugin/tsdetect.vim');
 };

--- a/src/entrypoints/coc.ts
+++ b/src/entrypoints/coc.ts
@@ -24,7 +24,8 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
   if (!paths.includes(context.extensionPath)) {
     await workspace.nvim.command(`execute 'noautocmd set runtimepath^='.fnameescape('${context.extensionPath}')`);
   }
-
+  await workspace.nvim.command('runtime plugin/tsdetect.vim');
+  
   // Setup manual commands.
   (['deno', 'node'] as const).forEach((target) => {
     context.subscriptions.push(
@@ -54,5 +55,4 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
 
   // Initialize after launched coc-tsdetect.
   await initialize(context);
-  await workspace.nvim.command('runtime plugin/tsdetect.vim');
 };

--- a/src/entrypoints/coc.ts
+++ b/src/entrypoints/coc.ts
@@ -25,7 +25,7 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
     await workspace.nvim.command(`execute 'noautocmd set runtimepath^='.fnameescape('${context.extensionPath}')`);
   }
   await workspace.nvim.command('runtime plugin/tsdetect.vim');
-  
+
   // Setup manual commands.
   (['deno', 'node'] as const).forEach((target) => {
     context.subscriptions.push(


### PR DESCRIPTION
We just run `:` by `autocmd Users tsdetect#detect :` . It suppresses undefined autocmds errors.
P.S. This pull request participates hacktoberfest. Please add the label. Thanks.